### PR TITLE
fix(oidc): Improve error handling

### DIFF
--- a/libs/oidc/CHANGELOG.md
+++ b/libs/oidc/CHANGELOG.md
@@ -2,7 +2,46 @@
 
 **Table of Contents**
 
-<!-- TOC -->autoauto- [Changelog](#changelog)auto    - [0.6.0 (2020-05-27)](#060-2020-05-27)auto        - [Features](#features)auto        - [Bug fixes](#bug-fixes)auto    - [0.5.0 (2020-05-19)](#050-2020-05-19)auto        - [Features](#features-1)auto        - [Bug fixes](#bug-fixes-1)auto        - [Documentation](#documentation)auto    - [0.4.0 (2020-05-06)](#040-2020-05-06)auto        - [Features](#features-2)auto    - [0.3.1 (2020-05-06)](#031-2020-05-06)auto        - [Bug fixes](#bug-fixes-2)auto    - [0.3.0 (2020-04-30)](#030-2020-04-30)auto        - [Features](#features-3)auto    - [0.2.1 (2020-04-30)](#021-2020-04-30)auto        - [Bug fixes](#bug-fixes-3)auto    - [0.2.0 (2020-04-23)](#020-2020-04-23)auto        - [Features](#features-4)auto            - [Before](#before)auto            - [Now](#now)auto    - [0.1.2 (2020-04-23)](#012-2020-04-23)auto        - [Bug fixes](#bug-fixes-4)autoauto<!-- /TOC -->
+<!-- TOC -->
+
+- [Changelog](#changelog)
+  - [0.6.1 (2020-06-03)](#061-2020-06-03)
+    - [Bugfixes](#bugfixes)
+  - [0.6.0 (2020-05-27)](#060-2020-05-27)
+    - [Features](#features)
+    - [Doc fixes](#doc-fixes)
+  - [0.5.0 (2020-05-19)](#050-2020-05-19)
+    - [Features](#features-1)
+    - [Bug fixes](#bug-fixes)
+    - [Documentation](#documentation)
+  - [0.4.0 (2020-05-06)](#040-2020-05-06)
+    - [Features](#features-2)
+  - [0.3.1 (2020-05-06)](#031-2020-05-06)
+    - [Bug fixes](#bug-fixes-1)
+  - [0.3.0 (2020-04-30)](#030-2020-04-30)
+    - [Features](#features-3)
+  - [0.2.1 (2020-04-30)](#021-2020-04-30)
+    - [Bug fixes](#bug-fixes-2)
+  - [0.2.0 (2020-04-23)](#020-2020-04-23)
+    - [Features](#features-4)
+      - [Before](#before)
+      - [Now](#now)
+  - [0.1.2 (2020-04-23)](#012-2020-04-23)
+    - [Bug fixes](#bug-fixes-3)
+
+<!-- /TOC -->
+
+## 0.6.1 (2020-06-03)
+
+### Bugfixes
+
+Previously, a wrongly configured issuer or one that didn't respond within configured timeout would result in a shady error, leaving the user clueless about what is the issue at hand.\
+Error handling was improved, with a link to the documentation and will terminate the application, as it is not usable :
+
+```
+[OidcModule] Error accessing the issuer/tokenStore. Check if the url is valid or increase the timeout in the defaultHttpOptions : https://github.com/fusionfabric/finastra-nodejs-libs/blob/develop/libs/oidc/README.md
+[OidcModule] Terminating application
+```
 
 ## 0.6.0 (2020-05-27)
 

--- a/libs/oidc/package.json
+++ b/libs/oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ffdc/nestjs-oidc",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "contributors": [
     "David Boclé <david.bocle@finastra.com>",
     "Francine Ong <francine.ong@finastra.com>"

--- a/libs/oidc/src/oidc.module.spec.ts
+++ b/libs/oidc/src/oidc.module.spec.ts
@@ -93,4 +93,39 @@ describe('OidcModule', () => {
       expect(module).toBeDefined();
     });
   });
+
+  describe('simulate error fetching issuer', () => {
+    let module: TestingModule;
+    let mockExit;
+
+    class oidcModuleOptions {
+      createModuleConfig() {
+        return MOCK_OIDC_MODULE_OPTIONS;
+      }
+    }
+
+    beforeEach(async () => {
+      const IssuerMock = MOCK_ISSUER_INSTANCE;
+      IssuerMock.keystore = jest.fn();
+      jest.spyOn(Issuer, 'discover').mockImplementation(() => Promise.reject());
+
+      mockExit = jest
+        .spyOn(process, 'exit')
+        .mockImplementation((code?: number): never => {
+          return undefined as never;
+        });
+
+      module = await Test.createTestingModule({
+        imports: [
+          OidcModule.forRootAsync({
+            useClass: oidcModuleOptions,
+          }),
+        ],
+      }).compile();
+    });
+
+    it('should terminate process', () => {
+      expect(mockExit).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/configs/oidc-config.service.ts
+++ b/src/configs/oidc-config.service.ts
@@ -20,7 +20,7 @@ export class OidcConfigService implements OidcOptionsFactory {
       },
       origin: this.configService.get('ORIGIN'),
       defaultHttpOptions: {
-        timeout: 1, //20000,
+        timeout: 20000,
       },
     };
   }

--- a/src/configs/oidc-config.service.ts
+++ b/src/configs/oidc-config.service.ts
@@ -20,7 +20,7 @@ export class OidcConfigService implements OidcOptionsFactory {
       },
       origin: this.configService.get('ORIGIN'),
       defaultHttpOptions: {
-        timeout: 20000,
+        timeout: 1, //20000,
       },
     };
   }


### PR DESCRIPTION
Previously, a wrongly configured issuer or one that didn't respond within configured timeout would result in a shady error, leaving the user clueless about what is the issue at hand.\
Error handling was improved, with a link to the documentation and will terminate the application, as it is not usable :

```
[OidcModule] Error accessing the issuer/tokenStore. Check if the url is valid or increase the timeout in the defaultHttpOptions : https://github.com/fusionfabric/finastra-nodejs-libs/blob/develop/libs/oidc/README.md
[OidcModule] Terminating application
```